### PR TITLE
Improve chat UI with avatars and updated layout

### DIFF
--- a/frontend/public/default-user.svg
+++ b/frontend/public/default-user.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#c5c6c7">
+  <circle cx="12" cy="7" r="5" />
+  <path d="M12 14c-6 0-10 3-10 5v3h20v-3c0-2-4-5-10-5z" />
+</svg>

--- a/frontend/src/components/Chat/Chat.jsx
+++ b/frontend/src/components/Chat/Chat.jsx
@@ -256,9 +256,12 @@ export const Chat = () => {
                   msg.sender_id === user?.id ? styles.myMessage : styles.theirMessage
                 }`}
               >
+                <div className={styles.messageHeader}>
+                  <img src="/default-user.svg" alt="avatar" className={styles.avatar} />
+                  <span className={styles.sender}>{msg.sender_name}</span>
+                </div>
                 <div className={styles.messageContent}>{msg.text}</div>
                 <div className={styles.messageInfo}>
-                  <span className={styles.sender}>{msg.sender_name}</span>
                   <span className={styles.timestamp}>
                     {new Date(msg.sent_at).toLocaleTimeString([], {
                       hour: '2-digit',

--- a/frontend/src/components/Chat/Chat.module.css
+++ b/frontend/src/components/Chat/Chat.module.css
@@ -232,15 +232,28 @@
   color: var(--black);
 }
 
+.messageHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+}
+
 .messageContent {
   margin-bottom: 4px;
   line-height: 1.4;
 }
 
+
 .messageInfo {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  justify-content: flex-end;
   margin-top: 4px;
   font-size: 12px;
   opacity: 0.7;
@@ -248,6 +261,7 @@
 
 .sender {
   font-weight: 600;
+  font-size: 1.1rem;
 }
 
 .timestamp {


### PR DESCRIPTION
## Summary
- display avatar and username above each message
- enlarge username text
- update message layout styles
- include a default avatar SVG

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in server *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ebf38f8b883309968eb2ee8fbb151